### PR TITLE
Fix import path for bitcask

### DIFF
--- a/proxy/main.go
+++ b/proxy/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"github.com/je4/bremote/common"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"log"
 	"os"
 	"os/signal"

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/je4/bremote/common"
 	"github.com/je4/ntp"
 	"github.com/op/go-logging"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"github.com/soheilhy/cmux"
 	"io/ioutil"
 	"net"


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇